### PR TITLE
Fix bug when previewing with empty string

### DIFF
--- a/app/controllers/simple_form_markdown_editor/previews_controller.rb
+++ b/app/controllers/simple_form_markdown_editor/previews_controller.rb
@@ -17,7 +17,7 @@ module SimpleFormMarkdownEditor
     end
 
     def text
-      params.require(:text)
+      params[:text].presence || ""
     end
 
     def options


### PR DESCRIPTION
I noticed an error on our production site when people where clicking preview without filling out text. The problem can be fixed by making this small change to the `previews_controller.rb`.

This is the exception stack trace:

```
ActionController::ParameterMissing (param is missing or the value is empty: text):
  actionpack (4.2.8) lib/action_controller/metal/strong_parameters.rb:251:in `require'
  simple_form_markdown_editor (0.0.9) app/controllers/simple_form_markdown_editor/previews_controller.rb:20:in `text'
  simple_form_markdown_editor (0.0.9) app/controllers/simple_form_markdown_editor/previews_controller.rb:16:in `text_preview'
  simple_form_markdown_editor (0.0.9) app/controllers/simple_form_markdown_editor/previews_controller.rb:8:in `block (2 levels) in preview'
  actionpack (4.2.8) lib/action_controller/metal/mime_responds.rb:217:in `respond_to'
  simple_form_markdown_editor (0.0.9) app/controllers/simple_form_markdown_editor/previews_controller.rb:7:in `preview'